### PR TITLE
Document Bedrock prompt caching

### DIFF
--- a/docs/docs/customize/model-providers/top-level/bedrock.mdx
+++ b/docs/docs/customize/model-providers/top-level/bedrock.mdx
@@ -10,15 +10,15 @@ Amazon Bedrock is a fully managed service on AWS that provides access to foundat
 
 ## Chat model
 
-We recommend configuring **Claude 3.5 Sonnet** as your chat model.
+We recommend configuring **Claude 3.7 Sonnet** as your chat model.
 
 <Tabs groupId="config-example">
   <TabItem value="yaml" label="YAML">
   ```yaml title="config.yaml"
   models:
-    - name: Claude 3.5 Sonnet
+    - name: Claude 3.7 Sonnet
       provider: bedrock
-      model: anthropic.claude-3-5-sonnet-20240620-v1:0
+      model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
       env:
         region: us-east-1
         profile: bedrock
@@ -31,9 +31,9 @@ We recommend configuring **Claude 3.5 Sonnet** as your chat model.
   {
     "models": [
       {
-        "title": "Claude 3.5 Sonnet", 
+        "title": "Claude 3.7 Sonnet",
         "provider": "bedrock",
-        "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
         "region": "us-east-1",
         "profile": "bedrock"
       }
@@ -146,6 +146,36 @@ We recommend configuring `cohere.rerank-v3-5:0` as your reranking model, you may
   ```
   </TabItem>
 </Tabs>
+
+## Prompt caching
+
+Bedrock allows Claude models to cache tool payloads, system messages, and chat
+messages between requests. Enable this behavior by adding
+`promptCaching: true` under `defaultCompletionOptions` in your model
+configuration.
+
+Prompt caching is generally available for:
+
+- Claude 3.7 Sonnet
+- Claude 3.5 Haiku
+- Amazon Nova Micro
+- Amazon Nova Lite
+- Amazon Nova Pro
+
+Customers who were granted access to Claude 3.5 Sonnet v2 during the prompt
+caching preview will retain that access, but it cannot be enabled for new users
+on that model.
+
+```yaml title="config.yaml"
+models:
+  - name: Claude 3.7 Sonnet
+    provider: bedrock
+    model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+    defaultCompletionOptions:
+      promptCaching: true
+```
+
+Prompt caching is not supported in JSON configuration files, so use the YAML syntax above to enable it.
 
 ## Authentication
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/model-providers/top-level/bedrock.md
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/customize/model-providers/top-level/bedrock.md
@@ -5,15 +5,15 @@ slug: ../bedrock
 
 ## 聊天模型
 
-我们推荐配置 **Claude 3.5 Sonnet** 作为你的聊天模型。
+我们推荐配置 **Claude 3.7 Sonnet** 作为你的聊天模型。
 
 ```json title="config.json"
 {
   "models": [
     {
-      "title": "Claude 3.5 Sonnet",
+      "title": "Claude 3.7 Sonnet",
       "provider": "bedrock",
-      "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
       "region": "us-east-1",
       "profile": "bedrock"
     }
@@ -47,6 +47,32 @@ Bedrock 当前不支持任何自动补全模型。
 Bedrock 当前没有任何重排序模型。
 
 [点击这里](../../model-roles/reranking.md) 查看重排序模型提供者列表。
+
+## 提示词缓存
+
+Bedrock 支持 Claude 模型的提示词缓存。 在 `defaultCompletionOptions`
+中设置 `promptCaching: true` 即可缓存工具调用、系统消息和聊天消息。
+
+提示词缓存目前适用于以下模型：
+
+- Claude 3.7 Sonnet
+- Claude 3.5 Haiku
+- Amazon Nova Micro
+- Amazon Nova Lite
+- Amazon Nova Pro
+
+在预览期间获准使用 Claude 3.5 Sonnet v2 的用户仍可继续使用提示词缓存，但该模型不会再向新的用户开放此功能。
+
+```yaml title="config.yaml"
+models:
+  - name: Claude 3.7 Sonnet
+    provider: bedrock
+    model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+    defaultCompletionOptions:
+      promptCaching: true
+```
+
+提示词缓存不支持 JSON 配置文件，只能在 YAML 中启用。
 
 ## 认证
 


### PR DESCRIPTION
## Summary
- document `defaultCompletionOptions.promptCaching` for AWS Bedrock Claude models
- clarify generally available models and limits for Claude 3.5 Sonnet v2
- add Chinese translation for new section
- specify that prompt caching is YAML-only
- use Claude 3.7 Sonnet in examples and update model name
- note JSON configs *are* not supported

## Testing
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_6845191bcc24832191799956ed642557